### PR TITLE
chore: remove upsampling

### DIFF
--- a/cfg/exps/no_upsampl/no_upsampling.yaml
+++ b/cfg/exps/no_upsampl/no_upsampling.yaml
@@ -1,0 +1,28 @@
+n_samples: 500000
+n_epochs: 2
+batch_size: 1
+patch_size: [256, 256]
+softround_temperature: [0.3, 0.1]
+noise_parameter: [0.25, 0.1]
+unfreeze_backbone: 20000 # After 20k samples, training is stable.
+workdir: null
+disable_wandb: False
+lmbda: 1e-3
+user_tag: no_upsampling
+
+hypernet_cfg:
+  synthesis:
+    hidden_dim: 1024
+    n_layers: 3
+  arm:
+    hidden_dim: 1024
+    n_layers: 3
+  backbone_arch: resnet50
+
+  dec_cfg:
+    config_name: hop
+    arm: 16,2
+    layers_synthesis: 48-1-linear-relu,X-1-linear-none,X-3-residual-relu,X-3-residual-none
+    n_ft_per_res: 1,1,1,1,1,1,1
+    ups_k_size: 8
+    ups_preconcat_k_size: 7

--- a/coolchic/utils/types.py
+++ b/coolchic/utils/types.py
@@ -279,7 +279,6 @@ class HyperNetConfig(BaseModel):
 
     synthesis: HyperNetParams = HyperNetParams(hidden_dim=1024, n_layers=3)
     arm: HyperNetParams = HyperNetParams(hidden_dim=1024, n_layers=3)
-    upsampling: HyperNetParams = HyperNetParams(hidden_dim=256, n_layers=1)
     backbone_arch: Literal["resnet18", "resnet50"] = "resnet18"
 
     patch_size: tuple[int, int] = (256, 256)


### PR DESCRIPTION
I ran an experiment and there is no performance loss if upsampling is performed exactly like initialized.